### PR TITLE
Fixed multi-task dealer name bug

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/enhanced-agent-task-attributes/custom-components/EnhancedAgentTaskDetails/EnchancedAgentTaskDetails.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/enhanced-agent-task-attributes/custom-components/EnhancedAgentTaskDetails/EnchancedAgentTaskDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { ITask } from '@twilio/flex-ui';
 import { Flex } from '@twilio-paste/core/flex';
 import { Text } from '@twilio-paste/core/text';
@@ -12,14 +13,19 @@ type EnhancedAgentTaskDetailsProps = {
 };
 
 const EnhancedAgentTaskDetails = ({ task }: EnhancedAgentTaskDetailsProps) => {
-  const [dealerName, setDealerName] = React.useState(task.attributes.dealerName || ''); // default empty string
-  const [editMode, setEditMode] = React.useState(false); // editMode state
+  const [dealerName, setDealerName] = useState(task.attributes.dealerName || ''); // default empty string
+  const [editMode, setEditMode] = useState(false); // editMode state
 
   const handleSubmit = (e: any) => {
     e.preventDefault(); // to prevent page refresh when the form is submitted
     task.setAttributes({ ...task.attributes, dealerName }); // update task attributes
     setEditMode(false); // switch off edit mode
   };
+
+  useEffect(() => {
+    // This function will be called anytime the task prop changes
+    setDealerName(task.attributes.dealerName || '');
+  }, [task]);
 
   return (
     <Flex hAlignContent="center" vertical>


### PR DESCRIPTION
### Summary

There was a bug for the dealer name, it works if you only had one task or multiple tasks with the same dealer name.  Where this surfaced is if you had multiple tasks at the same time with different dealer names.  I've added a useEffect to update the dealerName when rotating between tasks.

### Checklist

- [ x ] Tested changes end to end
